### PR TITLE
display of multipart messages

### DIFF
--- a/MailHog-UI/assets/js/controllers.js
+++ b/MailHog-UI/assets/js/controllers.js
@@ -181,7 +181,7 @@ mailhogApp.controller('MailCtrl', function ($scope, $http, $sce, $timeout) {
   $scope.getMessagePlain = function(message) {
     var l = $scope.findMatchingMIME(message, "text/plain");
     if(l != null && l !== "undefined") {
-      return l.Body;
+      return $scope.tryDecode(l);
     }
     return message.Content.Body;
 	}
@@ -217,11 +217,18 @@ mailhogApp.controller('MailCtrl', function ($scope, $http, $sce, $timeout) {
   $scope.getMessageHTML = function(message) {
     var l = $scope.findMatchingMIME(message, "text/html");
     if(l != null && l !== "undefined") {
-      return l.Body;
+      return $scope.tryDecode(l);
     }
   	return "<HTML not found>";
 	}
 
+  $scope.tryDecode = function(l){
+    if(l.Headers && l.Headers["Content-Type"] && l.Headers["Content-Transfer-Encoding"]){
+      return $scope.tryDecodeContent({Content:l},l.Body.replace(/=[\r\n]+/gm,""));
+    }else{
+      return l.Body;
+    }
+  };
   $scope.date = function(timestamp) {
   	return (new Date(timestamp)).toString();
   };

--- a/MailHog-UI/assets/templates/index.html
+++ b/MailHog-UI/assets/templates/index.html
@@ -228,7 +228,7 @@
     </ul>
     <div class="tab-content">
       <div ng-if="hasHTML(preview)" ng-class="{ active: hasHTML(preview) }" class="tab-pane" id="preview-html" ng-bind-html="preview.previewHTML"></div>
-      <div class="tab-pane" ng-class="{ active: !hasHTML(preview) }" id="preview-plain">{{ tryDecodeContent(preview, getMessagePlain(preview)) }}</div>
+      <div class="tab-pane" ng-class="{ active: !hasHTML(preview) }" id="preview-plain">{{ getMessagePlain(preview) }}</div>
       <div class="tab-pane" id="preview-source">{{ getSource(preview) }}</div>
       <div class="tab-pane" id="preview-mime">
         <div ng-repeat="part in preview.MIME.Parts" class="mime-part">


### PR DESCRIPTION
We had problems with multipart messages.
html was not properly decoded when it had transfer-type quoted-printables.
This should fix it.
