### PR TITLE
Update docs to refer to correct /api/v1 URL.

### DIFF
--- a/APIv1.md
+++ b/APIv1.md
@@ -3,39 +3,39 @@ Go-MailHog API v1
 
 The v1 API is a RESTful HTTP JSON API.
 
-### GET /v1/api/events
+### GET /api/v1/events
 
 Streams new messages using EventSource and chunked encoding
 
-### GET /v1/api/messages
+### GET /api/v1/messages
 
 Lists all messages excluding message content
 
-### DELETE /v1/api/messages
+### DELETE /api/v1/messages
 
 Deletes all messages
 
 Returns a ```200``` response code if message deletion was successful.
 
-### GET /v1/api/messages/{ message_id }
+### GET /api/v1/messages/{ message_id }
 
 Returns an individual message including message content
 
-### DELETE /v1/api/messages/{ message_id }
+### DELETE /api/v1/messages/{ message_id }
 
 Delete an individual message
 
 Returns a ```200``` response code if message deletion was successful.
 
-### GET /v1/api/messages/{ message_id }/download
+### GET /api/v1/messages/{ message_id }/download
 
 Download the complete message
 
-### GET /v1/api/messages/{ message_id }/mime/part/{ part_index }/download
+### GET /api/v1/messages/{ message_id }/mime/part/{ part_index }/download
 
 Download a MIME part
 
-### POST /v1/api/messages/{ message_id }/release
+### POST /api/v1/messages/{ message_id }/release
 
 Release the message to an SMTP server
 


### PR DESCRIPTION
Currently the API docs point to `/v1/api/[endpoint]`... but it looks like the _actual_ path is `/api/v1/[endpoint]`, so this PR updates it so it is correct.
