### PR TITLE
[doc] Remove comma from last value in smtp config JSON

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -41,7 +41,7 @@ the following structure, and set `MH_OUTGOING_SMTP` or `-outgoing-smtp`.
         "email": "...",
         "username": "...",
         "password": "...",
-        "mechanism": "PLAIN",
+        "mechanism": "PLAIN"
     }
 }
 ```


### PR DESCRIPTION
Mailhog would break with: `invalid character '}' looking for beginning of object key string`