### PR TITLE
[doc] Quote port number in smtp config JSON

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -37,7 +37,7 @@ the following structure, and set `MH_OUTGOING_SMTP` or `-outgoing-smtp`.
     "server name": {
         "name": "server name",
         "host": "...",
-        "port": 587,
+        "port": "587",
         "email": "...",
         "username": "...",
         "password": "...",


### PR DESCRIPTION
Mailhog would break with `json: cannot unmarshal number into Go value of type string`