### PR TITLE
optimize docker image size

### DIFF
--- a/Rockerfile
+++ b/Rockerfile
@@ -1,0 +1,14 @@
+# build image
+FROM golang:latest
+RUN go get -v github.com/mailhog/MailHog && \
+    cd /go/src && \
+    CGO_ENABLED=0 go build -a -installsuffix cgo -v -o /go/bin/MailHog.o github.com/mailhog/MailHog/main.go
+EXPORT /go/bin/ /target
+
+# run image
+FROM alpine:latest
+IMPORT /target/ /tmp
+RUN cp /tmp/MailHog.o /MailHog
+EXPOSE 1025 8025
+CMD ["/MailHog"]
+TAG mailhog/mailhog:{{ or .VERSION "latest" }}


### PR DESCRIPTION
this PR is to optimize the mailhog/MailHog docker image size by building with [Rocker](https://github.com/grammarly/rocker) tool.
Originally, the image size is around 600MB:
```
mailhog/mailhog          latest              554462932cb7        4 months ago        597.2 MB
```
Now, it's around 39MB:
```
mailhog/mailhog          latest              da5b63429efc        49 seconds ago       38.98 MB
```

please follow [instructions to install Rocker](https://github.com/grammarly/rocker#installation) first, then you can build as simple as:
```bash
rocker build
```