### PR TITLE
Provide a new configuration parameter ui-web-path

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,14 +14,23 @@ func DefaultConfig() *Config {
 
 type Config struct {
 	AuthFile string
+	WebPath  string
 }
 
 var cfg = DefaultConfig()
 
 func Configure() *Config {
+
+	//sanitize webpath
+	//add a leading slash
+	if cfg.WebPath != "" && !(cfg.WebPath[0] == '/') {
+		cfg.WebPath = "/" + cfg.WebPath
+	}
+
 	return cfg
 }
 
 func RegisterFlags() {
 	flag.StringVar(&cfg.AuthFile, "auth-file", envconf.FromEnvP("MH_AUTH_FILE", "").(string), "A username:bcryptpw mapping file")
+	flag.StringVar(&cfg.WebPath, "ui-web-path", envconf.FromEnvP("MH_UI_WEB_PATH", "").(string), "WebPath under which the ui is served (without leading or trailing slahes), e.g. 'mailhog'. Value defaults to ''")
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -15,6 +15,7 @@ You can configure MailHog using command line options or environment variables:
 | MH_SMTP_BIND_ADDR   | -smtp-bind-addr | 0.0.0.0:1025    | Interface and port for SMTP server to bind to
 | MH_STORAGE          | -storage        | memory          | Set message storage: memory / mongodb
 | MH_OUTGOING_SMTP    | -outgoing-smtp  |                 | JSON file defining outgoing SMTP servers
+| MH_UI_WEB_PATH      | -ui-web-path    |                 | WebPath under which the ui is served (without leading or trailing slahes), e.g. 'mailhog'. Value defaults to ''
 
 #### Note on HTTP bind addresses
 

--- a/main.go
+++ b/main.go
@@ -34,6 +34,9 @@ func configure() {
 	apiconf = cfgapi.Configure()
 	uiconf = cfgui.Configure()
 	comconf = cfgcom.Configure()
+
+	apiconf.WebPath = comconf.WebPath
+	uiconf.WebPath = comconf.WebPath
 }
 
 func main() {


### PR DESCRIPTION
This is the ConfigPart of the fix for  mailhog/Mailog#25.
It provides the new configuration parameter and sets its value to the MailHog-Server and MailHog-Ui.