### PR TITLE
API spec doesn't define the search query parameter

### DIFF
--- a/docs/APIv2/swagger-2.0.yaml
+++ b/docs/APIv2/swagger-2.0.yaml
@@ -104,6 +104,12 @@ paths:
           type: string
           enum: [ from, to, containing ]
         -
+          name: query
+          in: query
+          description: Search parameter
+          required: true
+          type: string
+        -
           name: start
           in: query
           description: Start index


### PR DESCRIPTION
Add query parameter "query" that is used to specify the actual search query. Without this it's not obvious how to search for a particular email.