### PR TITLE
Use single API constructor

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,14 +76,12 @@ func main() {
 	if uiconf.UIBindAddr == apiconf.APIBindAddr {
 		cb := func(r gohttp.Handler) {
 			web.CreateWeb(uiconf, r.(*pat.Router), assets.Asset)
-			api.CreateAPIv1(apiconf, r.(*pat.Router))
-			api.CreateAPIv2(apiconf, r.(*pat.Router))
+			api.CreateAPI(apiconf, r.(*pat.Router))
 		}
 		go http.Listen(uiconf.UIBindAddr, assets.Asset, exitCh, cb)
 	} else {
 		cb1 := func(r gohttp.Handler) {
-			api.CreateAPIv1(apiconf, r.(*pat.Router))
-			api.CreateAPIv2(apiconf, r.(*pat.Router))
+			api.CreateAPI(apiconf, r.(*pat.Router))
 		}
 		cb2 := func(r gohttp.Handler) {
 			web.CreateWeb(uiconf, r.(*pat.Router), assets.Asset)


### PR DESCRIPTION
Part of my fix for mailhog/MailHog#58

Individual public constructors for each API version were removed in GREsau/MailHog-Server@e7f979c845de6e9404a91875861a69cca2847f58 to clean up the interface and create a goroutine to forward new messages to both APIs for broadcasting.