### PR TITLE
Use golang:1.7-alpine base image. Resolves #108

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.4
+FROM golang:1.7-alpine
+
+RUN apk add --no-cache git \
+	&& rm -rf /var/cache/apk/*
 
 RUN go get github.com/mailhog/MailHog
 


### PR DESCRIPTION
Alpine based image is more than two times smaller than the standard (Debian based) one.
The resulting mailhog image size is 280.1 MB (using golang:1.7-alpine) vs 691.6 MB (using golang:1.7).
