### PR TITLE
Remove debug message

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,7 +62,6 @@ func main() {
 			log.Fatalf("error bcrypting password: %s", err)
 			os.Exit(1)
 		}
-		fmt.Println(string(b))
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
Hello,

I'm getting `localhost:1025 vagrant@sms` into STDERR every time when sending email.
Here is an example of simple PHP script:

```
vagrant@sms:~$ php -r "mail('test@ololo.com', 'Hello', 'Lorem ipsum dolor');"
localhost:1025 vagrant@sms
vagrant@sms:~$
```

Some sendmail related settings:

```
vagrant@sms:~$ php -i | grep sendmail
sendmail_from => no value => no value
sendmail_path => /usr/bin/env /home/vagrant/go/bin/mhsendmail dummy@example.com => /usr/bin/env /home/vagrant/go/bin/mhsendmail dummy@example.com
Path to sendmail => /usr/bin/env /home/vagrant/go/bin/mhsendmail dummy@example.com
```

I'm using the most recent version of MailHog.

If this output is important and should be kept it would be great to be able to disable it by some parameter.

Alex.
