### PR TITLE
Add a snapcraft.yaml file for building snaps (https://snapcraft.io)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,22 @@
+name: mailhog
+summary: Web and API based SMTP testing
+description: |
+ MailHog is an email testing tool for developers:
+ * Configure your application to use MailHog for SMTP delivery
+ * View messages in the web UI, or retrieve them with the JSON API
+ * Optionally release messages to real SMTP servers for delivery
+version: "master"
+confinement: strict
+grade: stable
+apps:
+  mailhog:
+    command: MailHog
+    plugs: [network-bind]
+    daemon: simple
+parts:
+  mailhog:
+    plugin: go
+    go-packages:
+      - github.com/mailhog/MailHog
+    build-packages:
+      - git


### PR DESCRIPTION
Hi,

This is a recipe for creating a snap package of MailHog, which can be installed on Ubuntu, Debian, Fedora, Gentoo, etc without further changes (http://snapcraft.io/docs/core/install).

Just run `snapcraft` from the same directory on Ubuntu 16.04+ (or via `docker run -v $PWD:/c snapcore/snapcraft sh -c "cd /c; snapcraft`) and it'll create the snap, which you can then publish to the world (after creating an account on https://myapps.developer.ubuntu.com):
>$ snapcraft login
>$ snapcraft register mailhog
>$ snapcraft push --release edge mailhog_master_amd64.snap

On any system with snapd installed it's just: `snap install --edge mailhog`.

You can even hook Travis up so that users subscribed to the edge channel automatically get the latest git commits: `snapcraft enable-ci travis`.

I think it would be a great way to bring more users to MailHog and simplify updates.