### PR TITLE
Added sendmail_path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Alternatively, you can use your native `sendmail` command by providing `-S`, for
 For example, in PHP you could add either of these lines to `php.ini`:
 
 ```
+sendmail_path = /usr/local/bin/mailhog sendmail test@example.org
 sendmail_path = /usr/local/bin/mhsendmail
 sendmail_path = /usr/sbin/sendmail -S mail:1025
 ```


### PR DESCRIPTION
I have tried those two lines of code and none of them worked (using Mac Os Sierra). I have also tried the mhsendmail but also without success. 

Then I have found https://www.drupal.org/docs/develop/local-server-setup/managing-mail-handling-for-development-or-testing and the following line works. Maybe it could save some time of searching to everyone else.
 
```
sendmail_path = /usr/local/bin/mailhog sendmail test@example.org
```
