### PR TITLE
Dockerfile: Switch Ports on EXPOSE for Dokku

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,5 @@ WORKDIR /home/mailhog
 
 ENTRYPOINT ["MailHog"]
 
-# Expose the SMTP and HTTP ports:
-EXPOSE 1025 8025
+# Expose the HTTP and SMTP ports:
+EXPOSE 8025 1025


### PR DESCRIPTION
To work out of the box with Dokku we should expose the http port first.
Dokku uses the first exposed port as webinterface.