### PR TITLE
Use official golang as base container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,10 @@
 # MailHog Dockerfile
 #
 
-FROM alpine:3.4
-
-# Install ca-certificates, required for the "release message" feature:
-RUN apk --no-cache add \
-    ca-certificates
+FROM golang:alpine
 
 # Install MailHog:
 RUN apk --no-cache add --virtual build-dependencies \
-    go \
     git \
   && mkdir -p /root/gocode \
   && export GOPATH=/root/gocode \


### PR DESCRIPTION
Docker is already providing a well supported base image for Go apps. Those official images are also continuously maintained and scanned for security issues.
Please note that this will also bump the version of Go to 1.9.3 and Alpine 3.6 (by the time of writing).

btw: would be great if you could fullfil the steps to become an "official" image yourself. :)

See also: https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/