### PR TITLE
Docker Image - Enable lower ports without root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ FROM alpine:3.4
 RUN apk --no-cache add \
     ca-certificates
 
+# install setcap
+RUN apk --no-cache add libcap 
+
 # Install MailHog:
 RUN apk --no-cache add --virtual build-dependencies \
     go \
@@ -18,6 +21,9 @@ RUN apk --no-cache add --virtual build-dependencies \
   && mv /root/gocode/bin/MailHog /usr/local/bin \
   && rm -rf /root/gocode \
   && apk del --purge build-dependencies
+
+# Enable access to low-number ports
+RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/local/bin/MailHog 
 
 # Add mailhog user/group with uid/gid 1000.
 # This is a workaround for boot2docker issue #581, see


### PR DESCRIPTION
We have a need to enable MailHog using port 25 (without mapping) within a Docker environment. Yes, this can be accomplished with the existing image, but it must run as 'root'. 

This particular PR uses setcap to give the MailHog executable privileged access to the lower ports, and this  allows the image to run with the default 'mailhog' user instead of root. 