### PR TITLE
Further optimize the Docker image.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,4 @@
-*
+.git
+docs
+*.md
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,19 @@
-#
-# MailHog Dockerfile
-#
+FROM golang:alpine as build
+WORKDIR /go/src/github.com/mailhog/MailHog
+COPY . .
+# Install MailHog as statically compiled binary:
+# ldflags explanation (see `go tool link`):
+#   -s  disable symbol table
+#   -w  disable DWARF generation
+RUN CGO_ENABLED=0 go install -ldflags='-s -w'
 
-FROM alpine:3.4
-
-# Install ca-certificates, required for the "release message" feature:
-RUN apk --no-cache add \
-    ca-certificates
-
-# Install MailHog:
-RUN apk --no-cache add --virtual build-dependencies \
-    go \
-    git \
-  && mkdir -p /root/gocode \
-  && export GOPATH=/root/gocode \
-  && go get github.com/mailhog/MailHog \
-  && mv /root/gocode/bin/MailHog /usr/local/bin \
-  && rm -rf /root/gocode \
-  && apk del --purge build-dependencies
-
-# Add mailhog user/group with uid/gid 1000.
-# This is a workaround for boot2docker issue #581, see
-# https://github.com/boot2docker/boot2docker/issues/581
-RUN adduser -D -u 1000 mailhog
-
-USER mailhog
-
-WORKDIR /home/mailhog
-
+FROM scratch
+# ca-certificates are required for the "release message" feature:
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /go/bin/MailHog /bin/
+# Avoid permission issues with host mounts by assigning a user/group with
+# uid/gid 1000 (usually the ID of the first user account on GNU/Linux):
+USER 1000:1000
 ENTRYPOINT ["MailHog"]
-
-# Expose the SMTP and HTTP ports:
+# Expose the SMTP and HTTP ports used by default by MailHog:
 EXPOSE 1025 8025


### PR DESCRIPTION
- Use the official golang:alpine image for the build. (see also #191).
- Build and install MailHog from the current repository instead of retrieving it from GitHub.
- Statically compile MailHog, so it can be installed without any dependencies.
- Disable symbol table and DWARF generation for a smaller binary size.
- Build the final Docker image from scratch, adding only the MailHog binary and ca-certificates.