### PR TITLE
add docker entrypoint and http basic auth envs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@
 
 FROM alpine:3.4
 
+ENV HTTP_BASIC_AUTH_USER="" \
+    HTTP_BASIC_AUTH_PASSWORD=""
+
 # Install ca-certificates, required for the "release message" feature:
 RUN apk --no-cache add \
     ca-certificates
@@ -28,7 +31,9 @@ USER mailhog
 
 WORKDIR /home/mailhog
 
-ENTRYPOINT ["MailHog"]
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod a+x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 # Expose the SMTP and HTTP ports:
 EXPOSE 1025 8025

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+if [ -n "$HTTP_BASIC_AUTH_USER" ] && [ -n "$HTTP_BASIC_AUTH_PASSWORD" ]
+then
+    echo "Generating password file: /home/mailhog/htpasswd"
+    echo "$HTTP_BASIC_AUTH_USER:$(MailHog bcrypt $HTTP_BASIC_AUTH_PASSWORD)" > /home/mailhog/htpasswd
+    MailHog -auth-file=/home/mailhog/htpasswd
+else
+    MailHog
+fi
+
+exit 0

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,9 +4,9 @@ if [ -n "$HTTP_BASIC_AUTH_USER" ] && [ -n "$HTTP_BASIC_AUTH_PASSWORD" ]
 then
     echo "Generating password file: /home/mailhog/htpasswd"
     echo "$HTTP_BASIC_AUTH_USER:$(MailHog bcrypt $HTTP_BASIC_AUTH_PASSWORD)" > /home/mailhog/htpasswd
-    MailHog -auth-file=/home/mailhog/htpasswd
+    exec "MailHog -auth-file=/home/mailhog/htpasswd $@"
 else
-    MailHog
+    exec "MailHog $@"
 fi
 
 exit 0

--- a/docs/Auth.md
+++ b/docs/Auth.md
@@ -35,6 +35,12 @@ This also works if you're running MailHog-UI and MailHog-Server separately:
     MailHog-Server -auth-file=docs/example-auth
     MailHog-UI -auth-file=docs/example-auth
 
+#### Using Docker's environment variables
+
+Pass `HTTP_BASIC_AUTH_USER` and `HTTP_BASIC_AUTH_PASSWORD` environment variables
+to the Docker container. Authentication file will be created on container startup
+and used by MailHog command.
+
 ## Future compatibility
 
 Authentication has been a bit of an experiment.


### PR DESCRIPTION
This will allow to avoid such entypoints :smile: 

```
entrypoint: sh -c "echo \"${BACKING_SERVICES_USER}:$$(MailHog bcrypt ${MAILHOG_PASSWORD})\" > /home/mailhog/htpasswd; MailHog -auth-file=/home/mailhog/htpasswd"
```

Hope you will release new image with that feature soon, I love MailHog! Thanks