### PR TITLE
Add storage limit for MongoDB and InMemory storage backends

### DIFF
--- a/vendor/github.com/mailhog/MailHog-Server/config/config.go
+++ b/vendor/github.com/mailhog/MailHog-Server/config/config.go
@@ -23,6 +23,7 @@ func DefaultConfig() *Config {
 		MongoColl:    "messages",
 		MaildirPath:  "",
 		StorageType:  "memory",
+		StorageLimit: 2000,
 		CORSOrigin:   "",
 		WebPath:      "",
 		MessageChan:  make(chan *data.Message),
@@ -39,6 +40,7 @@ type Config struct {
 	MongoDb          string
 	MongoColl        string
 	StorageType      string
+	StorageLimit     int
 	CORSOrigin       string
 	MaildirPath      string
 	InviteJim        bool
@@ -76,7 +78,7 @@ func Configure() *Config {
 		cfg.Storage = storage.CreateInMemory()
 	case "mongodb":
 		log.Println("Using MongoDB message storage")
-		s := storage.CreateMongoDB(cfg.MongoURI, cfg.MongoDb, cfg.MongoColl)
+		s := storage.CreateMongoDB(cfg.MongoURI, cfg.MongoDb, cfg.MongoColl, cfg.StorageLimit)
 		if s == nil {
 			log.Println("MongoDB storage unavailable, reverting to in-memory storage")
 			cfg.Storage = storage.CreateInMemory()

--- a/vendor/github.com/mailhog/MailHog-Server/config/config.go
+++ b/vendor/github.com/mailhog/MailHog-Server/config/config.go
@@ -75,13 +75,13 @@ func Configure() *Config {
 	switch cfg.StorageType {
 	case "memory":
 		log.Println("Using in-memory storage")
-		cfg.Storage = storage.CreateInMemory()
+		cfg.Storage = storage.CreateInMemory(cfg.StorageLimit)
 	case "mongodb":
 		log.Println("Using MongoDB message storage")
 		s := storage.CreateMongoDB(cfg.MongoURI, cfg.MongoDb, cfg.MongoColl, cfg.StorageLimit)
 		if s == nil {
 			log.Println("MongoDB storage unavailable, reverting to in-memory storage")
-			cfg.Storage = storage.CreateInMemory()
+			cfg.Storage = storage.CreateInMemory(cfg.StorageLimit)
 		} else {
 			log.Println("Connected to MongoDB")
 			cfg.Storage = s
@@ -123,7 +123,7 @@ func RegisterFlags() {
 	flag.StringVar(&cfg.APIBindAddr, "api-bind-addr", envconf.FromEnvP("MH_API_BIND_ADDR", "0.0.0.0:8025").(string), "HTTP bind interface and port for API, e.g. 0.0.0.0:8025 or just :8025")
 	flag.StringVar(&cfg.Hostname, "hostname", envconf.FromEnvP("MH_HOSTNAME", "mailhog.example").(string), "Hostname for EHLO/HELO response, e.g. mailhog.example")
 	flag.StringVar(&cfg.StorageType, "storage", envconf.FromEnvP("MH_STORAGE", "memory").(string), "Message storage: 'memory' (default), 'mongodb' or 'maildir'")
-	flag.IntVar(&cfg.StorageLimit, "storagelimit", envconf.FromEnvP("MH_STORAGELIMIT", 2000).(int), "Message storage limit: default 2000 messages")
+	flag.IntVar(&cfg.StorageLimit, "storage-limit", envconf.FromEnvP("MH_STORAGELIMIT", 2000).(int), "Message limit to store")
 	flag.StringVar(&cfg.MongoURI, "mongo-uri", envconf.FromEnvP("MH_MONGO_URI", "127.0.0.1:27017").(string), "MongoDB URI, e.g. 127.0.0.1:27017")
 	flag.StringVar(&cfg.MongoDb, "mongo-db", envconf.FromEnvP("MH_MONGO_DB", "mailhog").(string), "MongoDB database, e.g. mailhog")
 	flag.StringVar(&cfg.MongoColl, "mongo-coll", envconf.FromEnvP("MH_MONGO_COLLECTION", "messages").(string), "MongoDB collection, e.g. messages")

--- a/vendor/github.com/mailhog/MailHog-Server/config/config.go
+++ b/vendor/github.com/mailhog/MailHog-Server/config/config.go
@@ -123,6 +123,7 @@ func RegisterFlags() {
 	flag.StringVar(&cfg.APIBindAddr, "api-bind-addr", envconf.FromEnvP("MH_API_BIND_ADDR", "0.0.0.0:8025").(string), "HTTP bind interface and port for API, e.g. 0.0.0.0:8025 or just :8025")
 	flag.StringVar(&cfg.Hostname, "hostname", envconf.FromEnvP("MH_HOSTNAME", "mailhog.example").(string), "Hostname for EHLO/HELO response, e.g. mailhog.example")
 	flag.StringVar(&cfg.StorageType, "storage", envconf.FromEnvP("MH_STORAGE", "memory").(string), "Message storage: 'memory' (default), 'mongodb' or 'maildir'")
+	flag.IntVar(&cfg.StorageLimit, "storagelimit", envconf.FromEnvP("MH_STORAGELIMIT", 2000).(int), "Message storage limit: default 2000 messages")
 	flag.StringVar(&cfg.MongoURI, "mongo-uri", envconf.FromEnvP("MH_MONGO_URI", "127.0.0.1:27017").(string), "MongoDB URI, e.g. 127.0.0.1:27017")
 	flag.StringVar(&cfg.MongoDb, "mongo-db", envconf.FromEnvP("MH_MONGO_DB", "mailhog").(string), "MongoDB database, e.g. mailhog")
 	flag.StringVar(&cfg.MongoColl, "mongo-coll", envconf.FromEnvP("MH_MONGO_COLLECTION", "messages").(string), "MongoDB collection, e.g. messages")

--- a/vendor/github.com/mailhog/storage/memory.go
+++ b/vendor/github.com/mailhog/storage/memory.go
@@ -16,7 +16,8 @@ type InMemory struct {
 }
 
 // CreateInMemory creates a new in memory storage backend
-func CreateInMemory() *InMemory {
+func CreateInMemory(limit int) *InMemory {
+	StorageLimit = limit
 	return &InMemory{
 		MessageIDIndex: make(map[string]int),
 		Messages:       make([]*data.Message, 0),
@@ -27,6 +28,10 @@ func CreateInMemory() *InMemory {
 func (memory *InMemory) Store(m *data.Message) (string, error) {
 	memory.mu.Lock()
 	defer memory.mu.Unlock()
+	if len(memory.Messages) >= StorageLimit {
+		memory.Messages[len(memory.Messages)-1] = nil
+		memory.Messages = memory.Messages[:len(memory.Messages)-1]
+	}
 	memory.Messages = append(memory.Messages, m)
 	memory.MessageIDIndex[string(m.ID)] = len(memory.Messages) - 1
 	return string(m.ID), nil

--- a/vendor/github.com/mailhog/storage/mongodb.go
+++ b/vendor/github.com/mailhog/storage/mongodb.go
@@ -13,9 +13,6 @@ type MongoDB struct {
 	Collection *mgo.Collection
 }
 
-// Storage Limit
-var StorageLimit int = 0
-
 // CreateMongoDB creates a MongoDB backed storage backend
 func CreateMongoDB(uri, db, coll string, limit int) *MongoDB {
 	log.Printf("Connecting to MongoDB: %s\n", uri)

--- a/vendor/github.com/mailhog/storage/mongodb.go
+++ b/vendor/github.com/mailhog/storage/mongodb.go
@@ -100,15 +100,15 @@ func (mongo *MongoDB) List(start int, limit int) (*data.Messages, error) {
 
 // DeleteOne deletes an individual message by storage ID
 func (mongo *MongoDB) DeleteOne(id string) error {
-	// _, err := mongo.Collection.RemoveAll(bson.M{"id": id})
-	// Is faster to just drop the collection than delete all documents in it
-	_, err := mongo.Collection.DropCollection()
+	 _, err := mongo.Collection.RemoveAll(bson.M{"id": id})
 	return err
 }
 
 // DeleteAll deletes all messages stored in MongoDB
 func (mongo *MongoDB) DeleteAll() error {
-	_, err := mongo.Collection.RemoveAll(bson.M{})
+	//_, err := mongo.Collection.RemoveAll(bson.M{})
+	// Is faster to just drop the collection than delete all documents in it
+	err := mongo.Collection.DropCollection()
 	return err
 }
 

--- a/vendor/github.com/mailhog/storage/mongodb.go
+++ b/vendor/github.com/mailhog/storage/mongodb.go
@@ -100,7 +100,9 @@ func (mongo *MongoDB) List(start int, limit int) (*data.Messages, error) {
 
 // DeleteOne deletes an individual message by storage ID
 func (mongo *MongoDB) DeleteOne(id string) error {
-	_, err := mongo.Collection.RemoveAll(bson.M{"id": id})
+	// _, err := mongo.Collection.RemoveAll(bson.M{"id": id})
+	// Is faster to just drop the collection than delete all documents in it
+	_, err := mongo.Collection.DropCollection()
 	return err
 }
 

--- a/vendor/github.com/mailhog/storage/storage.go
+++ b/vendor/github.com/mailhog/storage/storage.go
@@ -2,6 +2,9 @@ package storage
 
 import "github.com/mailhog/data"
 
+// Storage limit
+var StorageLimit int = 0
+
 // Storage represents a storage backend
 type Storage interface {
 	Store(m *data.Message) (string, error)


### PR DESCRIPTION
Add storage limit for MongoDB and InMemory storage backends.

Added new switch: --storage-limit set to 2000 by default.

Changed how MongoDB storage purge all messages. No it drop collection to avoid to lock the database for a long period of time when the message count is too high.