### PR TITLE
Add wait-for-it.sh to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ FROM golang:alpine
 
 # Install MailHog:
 RUN apk --no-cache add --virtual build-dependencies \
+    bash \
     git \
+    wget \
   && mkdir -p /root/gocode \
   && export GOPATH=/root/gocode \
   && go get github.com/mailhog/MailHog \
@@ -18,6 +20,10 @@ RUN apk --no-cache add --virtual build-dependencies \
 # This is a workaround for boot2docker issue #581, see
 # https://github.com/boot2docker/boot2docker/issues/581
 RUN adduser -D -u 1000 mailhog
+
+# Download wait-for-it.sh
+RUN wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh \
+    && chmod a+x wait-for-it.sh
 
 USER mailhog
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -33,6 +33,18 @@ To mount the Maildir to the local filesystem, you can use a volume:
 
     docker run -d -e "MH_STORAGE=maildir" -v $PWD/maildir:/maildir -p 1025:1025 -p 8025:8025 mailhog/mailhog
 
+#### MongoDB
+
+You can run MailHog with a MongoDB for persisting messages. In order to prevent MailHog from falling back to in-memory storage, you can override the default Docker entrypoint with the `wait-for-it.sh` command.
+
+**docker-compose.yml**
+
+    services:
+      mailhog:
+        entrypoint: ["wait-for-it.sh", "mongo-db-host:27017", "--strict", "--timeout=120", "--", "MailHog"]
+
+This example waits 120s until a connection to the MongoDB can be established before starting MailHog. Please see https://github.com/vishnubob/wait-for-it for usage.
+
 ### Elastic Beanstalk
 
 You can deploy MailHog using [AWS Elastic Beanstalk](http://aws.amazon.com/elasticbeanstalk/).


### PR DESCRIPTION
**Motivation**

When running both, MailHog and MongoDB, in a Docker environment, it's not unlikely that the MailHog container is up and running before the MongoDB container. In this case MailHog will use its in-memory storage which probably is not what you want.

**Description**

This PR adds `wait-for-it.sh` from https://github.com/vishnubob/wait-for-it to the Docker image. This enables you to override the default `MailHog` entrypoint with `wait-for-it.sh` as shown below in an example Docker Compose file.

**docker-compose.yml**

    services:
      mailhog:
        entrypoint: ["wait-for-it.sh", "mongo-db-host:27017", "--strict", "--timeout=120", "--", "MailHog"]

This example waits 120s until a connection to the MongoDB can be established before starting MailHog.