### PR TITLE
Fix typos in CONFIG.md

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -5,7 +5,7 @@ You can configure MailHog using command line options or environment variables:
 
 | Environment         | Command line    | Default         | Description
 | ------------------- | --------------- | --------------- | -----------
-| MH_CORS_ORIGIN      | -cors-origin    |                 | If set, a Access-Control-Allow-Origin header is returned for API endpoints
+| MH_CORS_ORIGIN      | -cors-origin    |                 | If set, an Access-Control-Allow-Origin header is returned for API endpoints
 | MH_HOSTNAME         | -hostname       | mailhog.example | Hostname to use for EHLO/HELO and message IDs
 | MH_API_BIND_ADDR    | -api-bind-addr  | 0.0.0.0:8025    | Interface and port for HTTP API server to bind to
 | MH_UI_BIND_ADDR     | -ui-bind-addr   | 0.0.0.0:8025    | Interface and port for HTTP UI server to bind to
@@ -16,7 +16,7 @@ You can configure MailHog using command line options or environment variables:
 | MH_SMTP_BIND_ADDR   | -smtp-bind-addr | 0.0.0.0:1025    | Interface and port for SMTP server to bind to
 | MH_STORAGE          | -storage        | memory          | Set message storage: memory / mongodb / maildir
 | MH_OUTGOING_SMTP    | -outgoing-smtp  |                 | JSON file defining outgoing SMTP servers
-| MH_UI_WEB_PATH      | -ui-web-path    |                 | WebPath under which the ui is served (without leading or trailing slahes), e.g. 'mailhog'
+| MH_UI_WEB_PATH      | -ui-web-path    |                 | WebPath under which the UI is served (without leading or trailing slashes), e.g. 'mailhog'
 | MH_AUTH_FILE        | -auth-file      |                 | A username:bcryptpw mapping file
 
 #### Note on HTTP bind addresses


### PR DESCRIPTION
I fixed one spelling error (i.e. `slahes --> slashes`), one grammatical error (`a A... --> an A...`), and one spelling deviation (a previous line had `HTTP UI` capitalized, so I changed `ui --> UI`).