### PR TITLE
feat: use multistage build to minimize container size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,22 +2,22 @@
 # MailHog Dockerfile
 #
 
-FROM golang:alpine
+FROM golang:alpine as builder
 
 # Install MailHog:
 RUN apk --no-cache add --virtual build-dependencies \
     git \
   && mkdir -p /root/gocode \
   && export GOPATH=/root/gocode \
-  && go get github.com/mailhog/MailHog \
-  && mv /root/gocode/bin/MailHog /usr/local/bin \
-  && rm -rf /root/gocode \
-  && apk del --purge build-dependencies
+  && go get github.com/mailhog/MailHog
 
+FROM alpine:3
 # Add mailhog user/group with uid/gid 1000.
 # This is a workaround for boot2docker issue #581, see
 # https://github.com/boot2docker/boot2docker/issues/581
 RUN adduser -D -u 1000 mailhog
+
+COPY --from=builder /root/gocode/bin/MailHog /usr/local/bin/
 
 USER mailhog
 


### PR DESCRIPTION
This uses the multistage build functionality from Docker to be able to minimize the size of the containers.

From [here](https://hub.docker.com/r/mailhog/mailhog/tags) you can see that the latest tags are well over 100Mb which is ridiculously big for a Go compiled binary.

In an ideal case, we would use `FROM scratch` but the binary doesn't seem ready for that yet.