### PR TITLE
Allow MailHog to use privileged ports locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,14 @@ FROM golang:alpine
 
 # Install MailHog:
 RUN apk --no-cache add --virtual build-dependencies \
-    git \
+    git libcap \
   && mkdir -p /root/gocode \
   && export GOPATH=/root/gocode \
   && go get github.com/mailhog/MailHog \
   && mv /root/gocode/bin/MailHog /usr/local/bin \
   && rm -rf /root/gocode \
-  && apk del --purge build-dependencies
+  && setcap  CAP_NET_BIND_SERVICE=+eip /usr/local/bin/MailHog \
+  && apk del --purge build-dependencies libcap 
 
 # Add mailhog user/group with uid/gid 1000.
 # This is a workaround for boot2docker issue #581, see


### PR DESCRIPTION
MailHog allows to configure the port where it listens e.g. via
the environment variable MH_SMTP_BIND_ADDR. However privileged ports are
not allowed, since MailHog runs as normal user.
Using setcap the MailHog binary is allowed to bind on privileged ports

Closes #328