### PR TITLE
Update Dockerfile to go 1.18 syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@
 # MailHog Dockerfile
 #
 
-FROM golang:alpine as builder
+FROM golang:1.18-alpine as builder
 
 # Install MailHog:
 RUN apk --no-cache add --virtual build-dependencies \
     git \
   && mkdir -p /root/gocode \
   && export GOPATH=/root/gocode \
-  && go get github.com/mailhog/MailHog
+  && go install github.com/mailhog/MailHog@latest
 
 FROM alpine:3
 # Add mailhog user/group with uid/gid 1000.


### PR DESCRIPTION
## Description

This PR updates Mailhog Dockerfile to use a golang image with a specific version (1.18-alpine) to help keep things from breaking unexpectedly in the future. It also removes the deprecated `go get <package>` and replaces it with the equivalent `go install <package>@latest`.

When using this Dockerfile today, I got an error that looked like this:
```
#53 0.833 go: go.mod file not found in current directory or any parent directory.
#53 0.833       'go get' is no longer supported outside a module.
#53 0.833       To build and install a command, use 'go install' with a version,
#53 0.833       like 'go install example.com/cmd@latest'
#53 0.833       For more information, see https://golang.org/doc/go-get-install-deprecation
#53 0.833       or run 'go help get' or 'go help install'.
------
failed to solve: executor failed running [/bin/sh -c apk --no-cache add --virtual build-dependencies     git   && mkdir -p /root/gocode   && export GOPATH=/root/gocode   && go get github.com/mailhog/MailHog]: exit code: 1
make: *** [build] Error 17
```
I believe this is because the golang:alpine Docker image was updated to 1.18 recently, since 1.18 was released a couple of days ago. As of 1.18, `go get <package>` no longer builds executables. `go install <package>` should be used to install an executable instead.
See the deprecation message for more information: https://go.dev/doc/go-get-install-deprecation

## Testing plan

1. Make sure the image builds from this updated Dockerfile successfully
1. Make sure running the image works.