### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Then, start MailHog by running `mailhog` in the command line.
 #### Debian / Ubuntu
 ```bash
 sudo apt-get -y install golang-go
+sudo apt-get install git
 go get github.com/mailhog/MailHog
 ```
 


### PR DESCRIPTION
As a Ubuntu's user, to successfully run MailHog it was necessary to have git installed.
Without it Go can't compile MailHog and the bin folder won't exist.
So, I added a line to install git first before making go to get MailHog.
Don't know if git is also necessary in others platforms, but would be better to make it a requirement for installing MailHog.