### PR TITLE
Add route to HealthCheck (useful in deployments to GKE)

### DIFF
--- a/vendor/github.com/mailhog/MailHog-UI/web/web.go
+++ b/vendor/github.com/mailhog/MailHog-UI/web/web.go
@@ -37,9 +37,19 @@ func CreateWeb(cfg *config.Config, r http.Handler, asset func(string) ([]byte, e
 	pat.Path(WebPath + "/css/{file:.*}").Methods("GET").HandlerFunc(web.Static("assets/css/{{file}}"))
 	pat.Path(WebPath + "/js/{file:.*}").Methods("GET").HandlerFunc(web.Static("assets/js/{{file}}"))
 	pat.Path(WebPath + "/fonts/{file:.*}").Methods("GET").HandlerFunc(web.Static("assets/fonts/{{file}}"))
+	pat.Path(WebPath + "/healthz").Methods("GET").HandlerFunc(web.HealthCheck())
 	pat.StrictSlash(true).Path(WebPath + "/").Methods("GET").HandlerFunc(web.Index())
 
 	return web
+}
+
+func (web Web) HealthCheck() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, req *http.Request) {
+		log.Println("[UI] GET /healthz")
+
+		w.WriteHeader(200)
+		w.Write([]byte("UP"))
+	}
 }
 
 func (web Web) Static(pattern string) func(http.ResponseWriter, *http.Request) {

--- a/vendor/github.com/mailhog/http/server.go
+++ b/vendor/github.com/mailhog/http/server.go
@@ -84,7 +84,8 @@ func BasicAuthHandler(h http.Handler) http.Handler {
 		}
 
 		u, pw, ok := req.BasicAuth()
-		if !ok || !Authorised(u, pw) {
+
+		if (req.URL.Path != "/healthz") && (!ok || !Authorised(u, pw)) {
 			w.Header().Set("WWW-Authenticate", "Basic")
 			w.WriteHeader(401)
 			return


### PR DESCRIPTION
The purpose of this PR is to provide a route for checking the life of the service.
This is extremely useful when the service is being deployed to GKE using GCE Ingress control.
This was an open discussion and seen as a limitation in the service's helm graph, as can be seen here: https://github.com/codecentric/helm-charts/pull/627

Basically, when the service is configured with basic authentication, there is no route that returns Http code `2xx`, so the Ingress-GCE life check cannot validate that the HTTP port exposed by the service (`8025`) is working correctly. .

Signed-off-by: Julliano Goncalves <jullianow@gmail.com>