### PR TITLE
doc: Update README.md with Go >= v1.18.1 installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ brew update && brew install mailhog
 
 Then, start MailHog by running `mailhog` in the command line.
 
+#### Debian / Ubuntu Go >= v1.18.1
+```bash
+sudo apt-get -y install golang-go
+go install github.com/mailhog/MailHog@latest
+```
+
 #### Debian / Ubuntu Go < v1.18
 ```bash
 sudo apt-get -y install golang-go


### PR DESCRIPTION
## Summary
This PR updates the installation instructions in `README.md` for Debian/Ubuntu users who are using Go version 1.18.1 or higher. Due to the recent changes in Go's package management, specifically the deprecation of `go get` for installing executables, the installation steps have been revised to use the `go install` command with the `@latest` tag.

## Changes
- **Debian/Ubuntu Go >= v1.18.1:** A new section has been added for users with Go version 1.18.1 or newer. This section advises using `go install github.com/mailhog/MailHog@latest` for installation.

NOTE:
- Ideally, it should have been for `Go >= v1.18.0`, but keeping the previous install note from the author.

## References
- Go's official documentation regarding the deprecation: [Go Get Install Deprecation](https://golang.org/doc/go-get-install-deprecation)
