### PR TITLE
Updated Dockerfile to use golang:tip-alpine3.22 to build arm64 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,10 @@
 # MailHog Dockerfile
 #
 
-FROM golang:1.18-alpine as builder
+FROM golang:tip-alpine3.22 AS builder
 
 # Install MailHog:
-RUN apk --no-cache add --virtual build-dependencies \
-    git \
+RUN apk --no-cache add --virtual build-dependencies git \
   && mkdir -p /root/gocode \
   && export GOPATH=/root/gocode \
   && go install github.com/mailhog/MailHog@latest


### PR DESCRIPTION
The minimum version of go had changed to 1.22, so I updated the base image for the builder.